### PR TITLE
Add Windows Terminal transparency ignore rule

### DIFF
--- a/dot_config/komorebi/komorebi.json
+++ b/dot_config/komorebi/komorebi.json
@@ -107,6 +107,11 @@
       "kind": "Exe",
       "id": "wezterm-gui.exe",
       "matching_strategy": "Equals"
+    },
+    {
+      "kind": "Exe",
+      "id": "WindowsTerminal.exe",
+      "matching_strategy": "Equals"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Prevent Komorebi from making Windows Terminal transparent so its UI remains opaque during sessions.
- Keep terminal behavior consistent with the existing rule for `wezterm-gui.exe`.

### Description
- Updated `dot_config/komorebi/komorebi.json` to add a new entry to `transparency_ignore_rules` for the Windows Terminal executable with `"id": "WindowsTerminal.exe"` and `"matching_strategy": "Equals"`.
- Preserved the existing `wezterm-gui.exe` rule and the rest of the configuration unchanged.

### Testing
- Validated the edited JSON with `python -m json.tool dot_config/komorebi/komorebi.json >/dev/null`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a320ddda9bc83248fc6860e9be056fc)